### PR TITLE
add /connecttest.txt to readme

### DIFF
--- a/server.go
+++ b/server.go
@@ -15,6 +15,10 @@ func main() {
 		trace(w, r)
 		fmt.Fprintf(w, "Microsoft NCSI")
 	})
+	http.HandleFunc("/connecttest.txt", func(w http.ResponseWriter, r *http.Request) {
+		trace(w, r)
+		fmt.Fprintf(w, "Microsoft Connect Test")
+	})
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		trace(w, r)
 		fmt.Fprintf(w, "<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>")


### PR DESCRIPTION
Hello!
Thanks you for this project, i was just diggig into this mechanisms for a youtube video project.
I tested your container which is working well!

While doing so and learning about it, i just encountered this: 
if i'm not mistaken, on my Windows 11 computer, Windows now check for an another txt named connecttest.txt and for Microsoft Connect Test content

I have no idea if my pr is correct as i'm not a programmer, i just immitated the previous content:-)
Edit: stupid me forgot i was able to test by myself :-) **looks to be working!**

Please find a capture:
![image](https://user-images.githubusercontent.com/60965766/160018405-83a10a50-6ded-49cf-9ff4-24c80a07a012.png)
